### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ sudo: false
 node_js:
   - "0.11"
   - "0.10"
-matrix:
-  include:
-    - node_js: "0.8"
-      # old versions of NPM don't include support for `^` dependency prefixes in package.json
-      before_install: npm update -g npm
+
 notifications:
   email: false


### PR DESCRIPTION
versions of node are 12 or higher so we do not have to check for version 8 or before